### PR TITLE
feat: add viewport width/height parameters to test_accessibility and test_html_string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,16 @@ class AxeAccessibilityServer {
                 items: { type: 'string' },
                 description: 'Optional array of accessibility tags to test (e.g., "wcag2a", "wcag2aa", "wcag21a")',
                 default: ['wcag2aa']
+              },
+              width: {
+                type: 'number',
+                description: 'Viewport width in pixels (default: 1280)',
+                default: 1280
+              },
+              height: {
+                type: 'number',
+                description: 'Viewport height in pixels (default: 800)',
+                default: 800
               }
             },
             required: ['url'],
@@ -78,6 +88,16 @@ class AxeAccessibilityServer {
                 items: { type: 'string' },
                 description: 'Optional array of accessibility tags to test (e.g., "wcag2a", "wcag2aa", "wcag21a")',
                 default: ['wcag2aa']
+              },
+              width: {
+                type: 'number',
+                description: 'Viewport width in pixels (default: 1280)',
+                default: 1280
+              },
+              height: {
+                type: 'number',
+                description: 'Viewport height in pixels (default: 800)',
+                default: 800
               }
             },
             required: ['html'],
@@ -191,7 +211,7 @@ class AxeAccessibilityServer {
   }
 
   async testAccessibility(args: any) {
-    const { url, tags } = args;
+    const { url, tags, width = 1280, height = 800 } = args;
 
     if (!url) {
       throw new McpError(
@@ -207,9 +227,9 @@ class AxeAccessibilityServer {
         args: ['--no-sandbox', '--disable-setuid-sandbox']
       });
       const page = await browser.newPage();
-      
-      // Set a reasonable viewport
-      await page.setViewport({ width: 1280, height: 800 });
+
+      // Set viewport (defaults to 1280x800 for desktop)
+      await page.setViewport({ width, height });
       
       await page.goto(url, { waitUntil: 'networkidle0', timeout: 0 });
       
@@ -238,7 +258,7 @@ class AxeAccessibilityServer {
   }
 
   async testHtmlString(args: any) {
-    const { html, tags } = args;
+    const { html, tags, width = 1280, height = 800 } = args;
 
     if (!html) {
       throw new McpError(
@@ -254,9 +274,9 @@ class AxeAccessibilityServer {
         args: ['--no-sandbox', '--disable-setuid-sandbox']
       });
       const page = await browser.newPage();
-      
-      // Set a reasonable viewport
-      await page.setViewport({ width: 1280, height: 800 });
+
+      // Set viewport (defaults to 1280x800 for desktop)
+      await page.setViewport({ width, height });
       
       await page.setContent(html, { waitUntil: 'networkidle0' });
       


### PR DESCRIPTION
## Summary

Adds optional `width` and `height` parameters to `test_accessibility` and `test_html_string` tools, enabling accessibility testing at custom viewport sizes (e.g., mobile at 375x812).

Defaults to 1280x800 for full backwards compatibility — no breaking changes.

## Changes

- Added `width` (default: 1280) and `height` (default: 800) to the input schema for both `test_accessibility` and `test_html_string`
- Thread parameters through to `page.setViewport()` in both methods
- 1 file changed, 28 insertions, 8 deletions

## Motivation

Responsive sites render different elements at different breakpoints. Mobile layouts often include unique navigation, images, and interactive elements with their own accessibility issues not visible at desktop width. This change lets users test at any viewport size directly through the MCP tool.

Closes #3