### PR TITLE
docs: add installation instructions for multiple MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Web Accessibility-Testing MCP Server (A11y MCP)
-<a href="https://www.producthunt.com/products/web-accessibility-testing-mcp?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-web-accessibility-testing-mcp" target="_blank" rel="noopener noreferrer"><img alt="Web Accessibility Testing MCP -  Give LLMs access to web accessibility testing APIs | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1062073&amp;theme=light&amp;t=1768415232797"></a>
+
+<a href="https://www.producthunt.com/products/web-accessibility-testing-mcp?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-web-accessibility-testing-mcp" target="_blank" rel="noopener noreferrer"><img alt="Web Accessibility Testing MCP - Give LLMs access to web accessibility testing APIs | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1062073&theme=light&t=1768415232797"></a>
 
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/ronantakizawa-a11ymcp-badge.png)](https://mseep.ai/app/ronantakizawa-a11ymcp)
 
@@ -9,26 +10,17 @@
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@ronantakizawa/a11ymcp/badge" />
 </a>
 
-
-
 https://github.com/user-attachments/assets/316c6d44-e677-433e-b4d5-63630b4bab2b
 
+A11y MCP is an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that gives LLMs access to web accessibility testing APIs.
 
+This server uses the [Deque Axe-core](https://github.com/dequelabs/axe-core) API and [Puppeteer](https://pptr.dev/) to allow LLMs to analyze web content for WCAG compliance and identify accessibility issues.
 
-
-A11y MCP is an MCP (Model Context Protocol) server that gives LLMs access to web accessibility testing APIs. 
-
-This server uses the Deque Axe-core API and Puppeteer to allow LLMs to analyze web content for WCAG compliance and identify accessibility issues.
-
-NOTE: This is not an official MCP server from Deque Labs.
-
-Leave a star if you enjoyed the project! 🌟
-
-
+> **Note:** This is not an official MCP server from Deque Labs.
 
 ## Features
 
-- **Test web pages**: Test any public URL for accessibility issues
+- **Test web pages**: Test any public URL for accessibility issues with customizable viewport dimensions
 - **Test HTML snippets**: Test raw HTML strings for accessibility issues
 - **WCAG compliance testing**: Check content against various WCAG standards (2.0, 2.1, 2.2)
 - **Customizable tests**: Specify which accessibility tags/standards to test against
@@ -38,32 +30,99 @@ Leave a star if you enjoyed the project! 🌟
 - **Orientation lock detection**: Identify content that forces specific screen orientations
 
 ## Installation
-To use this server with Claude Desktop, you need to configure it in the MCP settings:
 
-**For macOS:**
-Edit the file at `'~/Library/Application Support/Claude/claude_desktop_config.json'`
+### Prerequisites
 
-```
+- [Node.js](https://nodejs.org/) 18 or later
+- An MCP-compatible client (Claude Desktop, Claude Code, VS Code, Cursor, etc.)
+
+### Claude Desktop
+
+Edit your MCP configuration file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
+
+Add the server to the `mcpServers` object:
+
+```json
 {
   "mcpServers": {
     "a11y-accessibility": {
-    "command": "npx",
-    "args": [
-      "-y",
-      "a11y-mcp-server"
-    ]
-   }
+      "command": "npx",
+      "args": ["-y", "a11y-mcp-server"]
+    }
   }
 }
 ```
 
-**For Windows:**
-Edit the file at `%APPDATA%\Claude\settings\claude_mcp_settings.json`
+### Claude Code (CLI)
 
-**For Linux:**
-Edit the file at `~/.config/Claude/settings/claude_mcp_settings.json`
-Replace `/path/to/axe-mcp-server/build/index.js` with the actual path to your compiled server file.
+```bash
+claude mcp add a11y-accessibility -- npx -y a11y-mcp-server
+```
 
+This registers the server for the current project. To make it available across all projects:
+
+```bash
+claude mcp add --scope user a11y-accessibility -- npx -y a11y-mcp-server
+```
+
+Verify the server is registered:
+
+```bash
+claude mcp list
+```
+
+> **Note:** MCP tools become available after restarting your Claude Code session.
+
+### VS Code (Copilot)
+
+Add to your VS Code `settings.json` or `.vscode/settings.json`:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "a11y-accessibility": {
+        "command": "npx",
+        "args": ["-y", "a11y-mcp-server"]
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to your Cursor MCP configuration (`.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "a11y-accessibility": {
+      "command": "npx",
+      "args": ["-y", "a11y-mcp-server"]
+    }
+  }
+}
+```
+
+### Windsurf
+
+Add to your Windsurf MCP configuration (`~/.codeium/windsurf/mcp_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "a11y-accessibility": {
+      "command": "npx",
+      "args": ["-y", "a11y-mcp-server"]
+    }
+  }
+}
+```
 
 ## Available Tools
 
@@ -72,42 +131,46 @@ Replace `/path/to/axe-mcp-server/build/index.js` with the actual path to your co
 Tests a URL for accessibility issues.
 
 **Parameters:**
-- `url` (required): The URL of the web page to test
-- `tags` (optional): Array of WCAG tags to test against (e.g., ["wcag2aa"])
-- `width` (optional): Viewport width in pixels (default: 1280)
-- `height` (optional): Viewport height in pixels (default: 800)
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `url` | Yes | The URL of the web page to test |
+| `tags` | No | Array of WCAG tags to test against (e.g., `["wcag2aa"]`) |
+| `width` | No | Viewport width in pixels (default: 1280) |
+| `height` | No | Viewport height in pixels (default: 800) |
 
-**Example - Desktop viewport (default):**
-
-```json
-{
- "url": "https://example.com",
- "tags": ["wcag2aa"]
-}
-```
-
-**Example - Mobile viewport (iPhone 12/13):**
+**Example — desktop viewport (default):**
 
 ```json
 {
- "url": "https://example.com",
- "tags": ["wcag2aa"],
- "width": 390,
- "height": 844
+  "url": "https://example.com",
+  "tags": ["wcag2aa"]
 }
 ```
+
+**Example — mobile viewport (iPhone 12/13):**
+
+```json
+{
+  "url": "https://example.com",
+  "tags": ["wcag2aa"],
+  "width": 390,
+  "height": 844
+}
+```
+
 ### test_html_string
 
 Tests an HTML string for accessibility issues.
 
 **Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `html` | Yes | The HTML content to test |
+| `tags` | No | Array of WCAG tags to test against (e.g., `["wcag2aa"]`) |
+| `width` | No | Viewport width in pixels (default: 1280) |
+| `height` | No | Viewport height in pixels (default: 800) |
 
-- `html` (required): The HTML content to test
-- `tags` (optional): Array of WCAG tags to test against (e.g., ["wcag2aa"])
-- `width` (optional): Viewport width in pixels (default: 1280)
-- `height` (optional): Viewport height in pixels (default: 800)
-
-**Example - Default viewport:**
+**Example — default viewport:**
 
 ```json
 {
@@ -116,7 +179,7 @@ Tests an HTML string for accessibility issues.
 }
 ```
 
-**Example - Mobile viewport:**
+**Example — mobile viewport:**
 
 ```json
 {
@@ -129,22 +192,42 @@ Tests an HTML string for accessibility issues.
 
 ### get_rules
 
-Get information about available accessibility rules with optional filtering.
+Get information about available accessibility rules with optional filtering. Returns an array of rule objects, each containing `ruleId`, `description`, `help`, `helpUrl`, and `tags`.
+
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `tags` | No | Filter rules by tags (e.g., `["wcag2a", "wcag2aa", "best-practice"]`) |
+
+**Example — filter rules by WCAG 2.1 AA:**
+
+```json
+{
+  "tags": ["wcag21aa"]
+}
+```
+
+**Example — get all rules (no filter):**
+
+```json
+{}
+```
 
 ### check_color_contrast
 
 Check if a foreground and background color combination meets WCAG contrast requirements.
 
 **Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `foreground` | Yes | Foreground color (e.g., `"#000000"`, `"rgb(0,0,0)"`) |
+| `background` | Yes | Background color (e.g., `"#FFFFFF"`, `"rgb(255,255,255)"`) |
+| `fontSize` | No | Font size in pixels (default: 16) |
+| `isBold` | No | Whether the text is bold (default: false) |
 
-- `foreground` (required): Foreground color in hex format (e.g., "#000000")
-- `background` (required): Background color in hex format (e.g., "#FFFFFF")
-- `fontSize` (optional): Font size in pixels (default: 16)
-- `isBold` (optional): Whether the text is bold (default: false)
+**Example:**
 
-Example
-
-```
+```json
 {
   "foreground": "#777777",
   "background": "#EEEEEE",
@@ -153,17 +236,18 @@ Example
 }
 ```
 
-### check_color_contrast
+### check_aria_attributes
 
 Check if ARIA attributes are used correctly in HTML.
 
 **Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `html` | Yes | HTML content to test for ARIA attribute usage |
 
-- `html` (required): HTML content to test for ARIA attribute usage
+**Example:**
 
-Example
-
-```
+```json
 {
   "html": "<div role='button' aria-pressed='false'>Click me</div>"
 }
@@ -174,20 +258,23 @@ Example
 Check if content forces a specific orientation.
 
 **Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `html` | Yes | HTML content to test for orientation lock issues |
 
-- `html` (required): HTML content to test for orientation lock issues
+**Example:**
 
-Example
-
-```
+```json
 {
   "html": "<html><head><meta name='viewport' content='width=device-width, orientation=portrait'></head><body>Content</body></html>"
 }
 ```
 
 ## Response Format
-The server returns accessibility test results in a structured JSON format:
-```
+
+The server returns accessibility test results in structured JSON:
+
+```json
 {
   "violations": [
     {
@@ -213,23 +300,31 @@ The server returns accessibility test results in a structured JSON format:
   "testEngine": {
     "name": "axe-core",
     "version": "4.10.3"
-  },
-  "testRunner": {
-    "name": "axe"
-  },
-  "testEnvironment": {
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/135.0.0.0 Safari/537.36",
-    "windowWidth": 800,
-    "windowHeight": 600,
-    "orientationAngle": 0,
-    "orientationType": "portrait-primary"
   }
 }
 ```
 
-### Dependencies
+## WCAG Tags Reference
 
-- @modelcontextprotocol/sdk
-- puppeteer
-- @axe-core/puppeteer
-- axe-core
+Common tags you can use with the `tags` parameter:
+
+| Tag | Description |
+|-----|-------------|
+| `wcag2a` | WCAG 2.0 Level A |
+| `wcag2aa` | WCAG 2.0 Level AA |
+| `wcag2aaa` | WCAG 2.0 Level AAA |
+| `wcag21a` | WCAG 2.1 Level A |
+| `wcag21aa` | WCAG 2.1 Level AA |
+| `wcag22aa` | WCAG 2.2 Level AA |
+| `best-practice` | Best practices (not strictly WCAG) |
+
+## Dependencies
+
+- [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/sdk)
+- [puppeteer](https://pptr.dev/)
+- [@axe-core/puppeteer](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/puppeteer)
+- [axe-core](https://github.com/dequelabs/axe-core)
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- Add prerequisites section (Node.js 18+)
- Add setup instructions for Claude Code, VS Code (Copilot), Cursor, and Windsurf alongside the existing Claude Desktop instructions
- Use parameter tables for all tools for better readability
- Add examples for `get_rules` (previously undocumented)
- Fix duplicate `check_color_contrast` heading that was masking the `check_aria_attributes` section
- Add WCAG tags reference table
- Add links to dependencies
- Add MIT license reference to README (matching LICENSE file)

## Notes

The existing Claude Desktop instructions are preserved and corrected (Windows path was previously pointing to the wrong file). All badge links and the demo video are retained.